### PR TITLE
Support carriage return in line endings

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -4,7 +4,7 @@ const fs = require("fs");
 const path = require("path");
 const program = require("commander");
 const chalk = require("chalk");
-const wpThemeVersionPattern = /^((?:<\?php\n)?\/\*\*?(?:.|\n)*Version:)(\s*)([\d.]*)((?:.|\n)+)/;
+const wpThemeVersionPattern = /^((?:<\?php\s+)?\/\*\*?[\s\S]*?Version:)(\s*)([\d.]*)/;
 
 run();
 
@@ -75,8 +75,8 @@ function getPackageJsonVersion() {
 }
 
 function replaceFileHeaderVersion(pathToFile, version) {
-  const replaceOutput = function(match, before, whitespace, oldVersion, after) {
-    return before + whitespace + version + after;
+  const replaceOutput = function(match, before, whitespace, oldVersion) {
+    return before + whitespace + version;
   };
   const file = fs.readFileSync(pathToFile, "utf8");
   return file.replace(wpThemeVersionPattern, replaceOutput);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -29,6 +29,23 @@ test("Replace version in file header", () => {
   });
 });
 
+test("Support CRLF line endings", () => {
+  let beforeFilePath = path.resolve(
+    __dirname,
+    `samples/php-file-header-crlf.before`
+  );
+  let afterFilePath = path.resolve(
+    __dirname,
+    `samples/php-file-header-crlf.after`
+  );
+ 
+  let afterFile = fs.readFileSync(afterFilePath, "utf8");
+ 
+  expect(replaceFileHeaderVersion(beforeFilePath, "1.1.0")).toEqual(
+    afterFile
+  );
+});
+
 test("Update file with new version in the file header", () => {
   let refFilePath = path.resolve(__dirname, 'samples/css-file-header.before');
   let refFile = fs.readFileSync(refFilePath, "utf8");

--- a/test/samples/php-file-header-crlf.after
+++ b/test/samples/php-file-header-crlf.after
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Plugin Name
+ *
+ * @package     PluginPackage
+ * @author      Your Name
+ * @copyright   2016 Your Name or Company Name
+ * @license     GPL-2.0+
+ *
+ * @wordpress-plugin
+ * Plugin Name: Plugin Name
+ * Plugin URI:  https://example.com/plugin-name
+ * Description: Description of the plugin.
+ * Version:     1.1.0
+ * Author:      Your Name
+ * Author URI:  https://example.com
+ * Text Domain: plugin-name
+ * License:     GPL-2.0+
+ * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+class FakeClass {
+    public function __construct() {
+        $this->foo = 'bar';
+    }
+}

--- a/test/samples/php-file-header-crlf.before
+++ b/test/samples/php-file-header-crlf.before
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Plugin Name
+ *
+ * @package     PluginPackage
+ * @author      Your Name
+ * @copyright   2016 Your Name or Company Name
+ * @license     GPL-2.0+
+ *
+ * @wordpress-plugin
+ * Plugin Name: Plugin Name
+ * Plugin URI:  https://example.com/plugin-name
+ * Description: Description of the plugin.
+ * Version:     1.0.0
+ * Author:      Your Name
+ * Author URI:  https://example.com
+ * Text Domain: plugin-name
+ * License:     GPL-2.0+
+ * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+class FakeClass {
+    public function __construct() {
+        $this->foo = 'bar';
+    }
+}


### PR DESCRIPTION
The original implementation used `\n` exclusively as a line ending, this allows `\r` as well. This is accomplished by making the regular expression more generic rather than just adding `\r`. 

Also included here, the regex matches non-greedily such that we get the first occurrence of `Version:` (in the comment) rather than the last occurrence (potentially elsewhere in the file). 

You also might want to consider full support for semver which can include characters other than digits (e.g. 0.4.0-beta+001) probably by taking any non-whitespace as the version to replace.